### PR TITLE
36 dodaj unit testy do wszystkich wyjtkw

### DIFF
--- a/API/Entities/Auth/Queries/LoginQuery.cs
+++ b/API/Entities/Auth/Queries/LoginQuery.cs
@@ -28,11 +28,12 @@ namespace AlpimiAPI.Auth.Queries
                 WHERE [Login] = @Login;",
                 request
             );
-            var user = await _dbService.Post<User.User?>(
-                @"SELECT [Id],[Login],[CustomURL]
-                FROM [User] 
-                WHERE [Login] = @Login;",
-                request
+
+            GetUserByLoginHandler getUserByLoginHandler = new GetUserByLoginHandler(_dbService);
+            GetUserByLoginQuery getUserByLoginQuery = new GetUserByLoginQuery(request.Login);
+            ActionResult<User.User?> user = await getUserByLoginHandler.Handle(
+                getUserByLoginQuery,
+                cancellationToken
             );
 
             if (auth == null || user == null)
@@ -52,7 +53,7 @@ namespace AlpimiAPI.Auth.Queries
             {
                 new Claim(ClaimTypes.NameIdentifier, auth.UserID.ToString()),
                 new Claim("login", $"{auth.User.Login}"),
-                new Claim("userID", $"{auth.UserID}")
+                new Claim("userID", $"{auth.UserID}"),
             };
 
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration.GetJWTKey()));

--- a/API/Entities/User/UserController.cs
+++ b/API/Entities/User/UserController.cs
@@ -84,9 +84,9 @@ namespace AlpimiAPI.User
             {
                 return Unauthorized();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return BadRequest("TODO make a message");
+                return BadRequest(ex);
             }
         }
 


### PR DESCRIPTION
żeby spowodować że LoginQuery uznaje nieprawidłowy login trzeba ustawić by mock db zwracał nulla (czyli w przypadku gdyby login by niepoprawny)