### PR TITLE
46 uniemoliw tworzenia dwch identycznych customurl

### DIFF
--- a/API/Entities/EUser/Commands/CreateUserCommand.cs
+++ b/API/Entities/EUser/Commands/CreateUserCommand.cs
@@ -43,8 +43,8 @@ namespace AlpimiAPI.Entities.EUser.Commands
 
             var userURL = await _dbService.Get<string>(
                 @"SELECT [CustomURL]
-    FROM [User]
-    WHERE [CustomURL] = @CustomURL;",
+                FROM [User]
+                WHERE [CustomURL] = @CustomURL;",
                 request
             );
             if (userURL != null)

--- a/API/Entities/EUser/Commands/UpdateUserCommand.cs
+++ b/API/Entities/EUser/Commands/UpdateUserCommand.cs
@@ -18,6 +18,16 @@ namespace AlpimiAPI.Entities.EUser.Commands
             CancellationToken cancellationToken
         )
         {
+            var userURL = await _dbService.Get<string>(
+                @"SELECT [CustomURL]
+                FROM [User]
+                WHERE [CustomURL] = @CustomURL;",
+                request
+            );
+            if (userURL != null)
+            {
+                throw new BadHttpRequestException("URL already taken");
+            }
             var user = await _dbService.Update<User?>(
                 @"
                     UPDATE [User] 

--- a/API/Utilities/Privileges.cs
+++ b/API/Utilities/Privileges.cs
@@ -7,11 +7,6 @@ namespace AlpimiAPI.Utilities
     {
         public static bool CheckOwnership(string authorization, Guid id)
         {
-            if (authorization is null)
-            {
-                return false;
-            }
-
             var token = authorization.ToString().Split(" ").Last();
             var jwtHandler = new JwtSecurityTokenHandler();
             var jwtToken = jwtHandler.ReadJwtToken(token);

--- a/API/Utilities/Privileges.cs
+++ b/API/Utilities/Privileges.cs
@@ -1,0 +1,27 @@
+﻿using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace AlpimiAPI.Utilities
+{
+    public static class Privileges
+    {
+        public static bool CheckOwnership(string authorization, Guid id)
+        {
+            if (authorization is null)
+            {
+                return false;
+            }
+
+            var token = authorization.ToString().Split(" ").Last();
+            var jwtHandler = new JwtSecurityTokenHandler();
+            var jwtToken = jwtHandler.ReadJwtToken(token);
+            Claim userIdClaim = jwtToken.Claims.FirstOrDefault(c => c.Type == "userID")!;
+
+            if (Guid.Parse(userIdClaim.Value) != id)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Dodałem sprawdzanie czy uzytkownik może zmieniać/getować informacje
usuwanie zostanie zmienione na Admina więc je zostawiłem

sprawdzam przed wykoniem query czy uzytkownik moze to zrobić
ale jak nie jest podane ID to po wykonaniu query (np. w getbylogin)

sprawdź czy ci sie podoba bo mogą być problemy że najpierw rzuca null exception a potem unothoriezed
można zduplikować sprawdzanie nulla żeby tak nie było
