### PR TITLE
Removed bool from lesson block update endpoint

### DIFF
--- a/API/Entities/ELessonBlock/Commands/UpdateLessonBlockCommand.cs
+++ b/API/Entities/ELessonBlock/Commands/UpdateLessonBlockCommand.cs
@@ -82,7 +82,7 @@ namespace AlpimiAPI.Entities.ELessonBlock.Commands
                     null,
                     request.FilteredId,
                     request.Role,
-                    new PaginationParams(1, 0, "LessonDate", "ASC")
+                    new PaginationParams(1, 0, "LessonDate", "DESC")
                 );
                 ActionResult<(IEnumerable<LessonBlock>?, int)> finalLessonBlock =
                     await getFirstLessonBlocksHandler.Handle(

--- a/API/Entities/ELessonBlock/Commands/UpdateLessonBlockCommand.cs
+++ b/API/Entities/ELessonBlock/Commands/UpdateLessonBlockCommand.cs
@@ -39,71 +39,64 @@ namespace AlpimiAPI.Entities.ELessonBlock.Commands
         {
             LessonBlock oneLessonBlock;
             LessonBlock lastLessonBlock;
-            int amountOfLessonsToUpdate = 1;
-            int amountOfLessonHoursToUpdate;
 
-            if (request.dto.UpdateCluster)
+            GetLessonBlockHandler getLessonBlockHandler = new GetLessonBlockHandler(_dbService);
+            GetLessonBlockQuery getLessonBlockQuery = new GetLessonBlockQuery(
+                request.Id,
+                request.FilteredId,
+                request.Role
+            );
+            ActionResult<LessonBlock?> lessonBlock = await getLessonBlockHandler.Handle(
+                getLessonBlockQuery,
+                cancellationToken
+            );
+
+            if (lessonBlock.Value == null)
             {
-                GetAllLessonBlocksHandler getAllLessonBlocksHandler = new GetAllLessonBlocksHandler(
-                    _dbService,
-                    _str
-                );
-                GetAllLessonBlocksQuery getAllLessonBlocksQuery = new GetAllLessonBlocksQuery(
+                GetAllLessonBlocksHandler getFirstLessonBlocksHandler =
+                    new GetAllLessonBlocksHandler(_dbService, _str);
+                GetAllLessonBlocksQuery getFirstLessonBlocksQuery = new GetAllLessonBlocksQuery(
                     request.Id,
                     null,
                     null,
                     request.FilteredId,
                     request.Role,
-                    new PaginationParams(int.MaxValue, 0, "LessonDate", "ASC")
+                    new PaginationParams(1, 0, "LessonDate", "ASC")
                 );
-                ActionResult<(IEnumerable<LessonBlock>?, int)> lessonBlocks =
-                    await getAllLessonBlocksHandler.Handle(
-                        getAllLessonBlocksQuery,
+                ActionResult<(IEnumerable<LessonBlock>?, int)> firstLessonBlock =
+                    await getFirstLessonBlocksHandler.Handle(
+                        getFirstLessonBlocksQuery,
                         cancellationToken
                     );
 
-                if (lessonBlocks.Value.Item2 == 0)
+                if (firstLessonBlock.Value.Item2 == 0)
                 {
                     return null;
                 }
-                oneLessonBlock = lessonBlocks.Value.Item1!.First();
-                lastLessonBlock = lessonBlocks.Value.Item1!.Last();
-                amountOfLessonsToUpdate = lessonBlocks.Value.Item2;
-                amountOfLessonHoursToUpdate =
-                    (
-                        (
-                            request.dto.LessonEnd
-                            ?? oneLessonBlock.LessonEnd - request.dto.LessonStart
-                            ?? oneLessonBlock.LessonStart + 1
-                        ) - (oneLessonBlock.LessonEnd - oneLessonBlock.LessonStart + 1)
-                    ) * lessonBlocks.Value.Item2;
+
+                GetAllLessonBlocksHandler getLastLessonBlocksHandler =
+                    new GetAllLessonBlocksHandler(_dbService, _str);
+                GetAllLessonBlocksQuery getLastLessonBlocksQuery = new GetAllLessonBlocksQuery(
+                    request.Id,
+                    null,
+                    null,
+                    request.FilteredId,
+                    request.Role,
+                    new PaginationParams(1, 0, "LessonDate", "ASC")
+                );
+                ActionResult<(IEnumerable<LessonBlock>?, int)> finalLessonBlock =
+                    await getFirstLessonBlocksHandler.Handle(
+                        getFirstLessonBlocksQuery,
+                        cancellationToken
+                    );
+
+                oneLessonBlock = firstLessonBlock.Value.Item1!.First();
+                lastLessonBlock = firstLessonBlock.Value.Item1!.First();
             }
             else
             {
-                GetLessonBlockHandler getLessonBlockHandler = new GetLessonBlockHandler(_dbService);
-                GetLessonBlockQuery getLessonBlockQuery = new GetLessonBlockQuery(
-                    request.Id,
-                    request.FilteredId,
-                    request.Role
-                );
-                ActionResult<LessonBlock?> lessonBlock = await getLessonBlockHandler.Handle(
-                    getLessonBlockQuery,
-                    cancellationToken
-                );
-
-                if (lessonBlock.Value == null)
-                {
-                    return null;
-                }
-
                 oneLessonBlock = lessonBlock.Value;
                 lastLessonBlock = oneLessonBlock;
-                amountOfLessonHoursToUpdate =
-                    (
-                        request.dto.LessonEnd
-                        ?? oneLessonBlock.LessonEnd - request.dto.LessonStart
-                        ?? oneLessonBlock.LessonStart + 1
-                    ) - (oneLessonBlock.LessonEnd - oneLessonBlock.LessonStart + 1);
             }
 
             List<ErrorObject> errors = new List<ErrorObject>();

--- a/API/Entities/ELessonBlock/DTO/UpdateLessonBlockDTO.cs
+++ b/API/Entities/ELessonBlock/DTO/UpdateLessonBlockDTO.cs
@@ -13,8 +13,5 @@ namespace AlpimiAPI.Entities.ELessonBlock.DTO
         public Guid? ClassroomId { get; set; }
 
         public Guid? TeacherId { get; set; }
-
-        [Required]
-        public required bool UpdateCluster { get; set; }
     }
 }

--- a/API/Entities/ELessonBlock/LessonBlockController.cs
+++ b/API/Entities/ELessonBlock/LessonBlockController.cs
@@ -113,8 +113,8 @@ namespace AlpimiAPI.Entities.ELessonBlock
         /// Updates one or multiple LessonBlocks
         /// </summary>
         /// <remarks>
-        /// To update multiple LessonBlocks provide a valid ClusterId and set UpdateCluster to true.
-        /// To update one LessonBlock provide a valid LessonBlockId and set UpdateCluster to false.
+        /// To update multiple LessonBlocks provide a valid ClusterId.
+        /// To update one LessonBlock provide a valid LessonBlockId.
         /// - JWT token is required
         /// </remarks>
         [HttpPatch("{id}")]

--- a/Test/Entities/ELessonBlock/LessonBlockController.test.cs
+++ b/Test/Entities/ELessonBlock/LessonBlockController.test.cs
@@ -324,7 +324,6 @@ namespace AlpimiTest.Entities.ELessonBlock
         public async Task UpdateLessonBlockUpdatesLessonBlockCluster()
         {
             var lessonBlockUpdateRequest = MockData.GetUpdateLessonBlockDTODetails();
-            lessonBlockUpdateRequest.UpdateCluster = true;
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
                 "Bearer",
                 TestAuthorization.GetToken("Admin", "Bob", userId)
@@ -347,7 +346,6 @@ namespace AlpimiTest.Entities.ELessonBlock
         public async Task UpdateLessonBlockUpdatesLessonsCurrentHours()
         {
             var lessonBlockUpdateRequest = MockData.GetUpdateLessonBlockDTODetails();
-            lessonBlockUpdateRequest.UpdateCluster = true;
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
                 "Bearer",
                 TestAuthorization.GetToken("Admin", "Bob", userId)

--- a/Test/TestUtilities/MockData.cs
+++ b/Test/TestUtilities/MockData.cs
@@ -596,7 +596,6 @@ namespace AlpimiTest.TestUtilities
                 LessonStart = 2,
                 LessonEnd = 3,
                 WeekDay = 2,
-                UpdateCluster = false
             };
         }
     }


### PR DESCRIPTION
niby ciąg dalszy optymalizacji
tera update nie pobiera WSZYSTKICH (prawie) lesson blocków
tylko używa getall do pobrania pierwszego i ostatniego lesson blocka (obydwa są potrzebne)
ale za to
albert ma 1 zmienną mniej do updateowania lesson blocków