### PR TITLE
Change ubuntu version to 22.04

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -52,7 +52,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Polecenie `sqlcmd` nie jest rozpoznawane przez Ubuntu 24.04, więc do stawiania serwera SQL w pipelinach trzeba używać Ubuntu w wersji 22.04