### PR TITLE
168 ogranicz długoś trwania roku szkolnego

### DIFF
--- a/API/Entities/ESchedule/Commands/CreateScheduleCommand.cs
+++ b/API/Entities/ESchedule/Commands/CreateScheduleCommand.cs
@@ -48,7 +48,16 @@ namespace AlpimiAPI.Entities.ESchedule.Commands
             {
                 errors.Add(new ErrorObject(_str["badParameter", "SchoolDays"]));
             }
-
+            if (
+                (request.dto.SchoolYearEnd.Year - request.dto.SchoolYearStart.Year) * 12
+                    + (request.dto.SchoolYearEnd.Month - request.dto.SchoolYearStart.Month)
+                > Configuration.maxSchoolYearDuration
+            )
+            {
+                errors.Add(
+                    new ErrorObject(_str["scheduleDuration", Configuration.maxSchoolYearDuration])
+                );
+            }
             AllowedCharacterTypes[]? allowedCharacterTypesScheduleName =
                 Configuration.GetAllowedCharacterTypesForScheduleName();
 

--- a/API/Entities/EScheduleSettings/Commands/UpdateScheduleSettingsCommand.cs
+++ b/API/Entities/EScheduleSettings/Commands/UpdateScheduleSettingsCommand.cs
@@ -8,6 +8,7 @@ using AlpimiAPI.Entities.EScheduleSettings.DTO;
 using AlpimiAPI.Entities.EScheduleSettings.Queries;
 using AlpimiAPI.Locales;
 using AlpimiAPI.Responses;
+using AlpimiAPI.Utilities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
@@ -92,9 +93,28 @@ namespace AlpimiAPI.Entities.EScheduleSettings.Commands
                 request.dto.SchoolDays ?? originalScheduleSettings.Value.SchoolDays;
             request.dto.IsPublic = request.dto.IsPublic ?? originalScheduleSettings.Value.IsPublic;
 
+            if (
+                (request.dto.SchoolYearEnd.Value.Year - request.dto.SchoolYearStart.Value.Year) * 12
+                    + (
+                        request.dto.SchoolYearEnd.Value.Month
+                        - request.dto.SchoolYearStart.Value.Month
+                    )
+                > Configuration.maxSchoolYearDuration
+            )
+            {
+                errors.Add(
+                    new ErrorObject(_str["scheduleDuration", Configuration.maxSchoolYearDuration])
+                );
+            }
+
             if (request.dto.SchoolYearStart > request.dto.SchoolYearEnd)
             {
-                throw new ApiErrorException([new ErrorObject(_str["scheduleDate"])]);
+                errors.Add(new ErrorObject(_str["scheduleDate"]));
+            }
+
+            if (errors.Count != 0)
+            {
+                throw new ApiErrorException(errors);
             }
 
             var daysOffOutOfRange = await _dbService.GetAll<DayOff>(

--- a/API/Locales/Errors.pl-PL.resx
+++ b/API/Locales/Errors.pl-PL.resx
@@ -189,4 +189,7 @@
   <data name="cantContain" xml:space="preserve">
     <value>{0} może tylko zawierać następujące: {1}</value>
   </data>
+  <data name="scheduleDuration" xml:space="preserve">
+    <value>Rok szkolny nie może trwać dłużej niż {0} mies.</value>
+  </data>
 </root>

--- a/API/Locales/Errors.resx
+++ b/API/Locales/Errors.resx
@@ -189,4 +189,7 @@
   <data name="cantContain" xml:space="preserve">
     <value>{0} can only contain the following: {1}</value>
   </data>
+  <data name="scheduleDuration" xml:space="preserve">
+    <value>The school year cannot be longer than {0} month(s)</value>
+  </data>
 </root>

--- a/API/Utilities/Configuration.cs
+++ b/API/Utilities/Configuration.cs
@@ -31,6 +31,7 @@ namespace AlpimiAPI.Utilities
         private static readonly string? _timeWindow = Environment.GetEnvironmentVariable(
             "TIME_WINDOW"
         );
+        public static int maxSchoolYearDuration { get; set; } = 24;
         public const int perPage = PaginationSettings.perPage;
         public const int page = PaginationSettings.page;
         public const string sortBy = PaginationSettings.sortBy;

--- a/Test/Entities/ESchedule/Commands/CreateScheduleCommand.unit.cs
+++ b/Test/Entities/ESchedule/Commands/CreateScheduleCommand.unit.cs
@@ -249,5 +249,40 @@ namespace AlpimiTest.Entities.ESchedule.Commands
                 JsonConvert.SerializeObject(result.errors)
             );
         }
+
+        [Fact]
+        public async Task ThrowsErrorWhenSchoolYearDurationExceedsMaximumDuration()
+        {
+            var dto = MockData.GetCreateScheduleDTODetails();
+            dto.SchoolYearEnd = new DateOnly(2029, 10, 10);
+            var scheduleSettings = MockData.GetScheduleSettingsDetails();
+
+            var createScheduleCommand = new CreateScheduleCommand(
+                scheduleSettings.Schedule.Id,
+                scheduleSettings.Schedule.UserId,
+                scheduleSettings.Id,
+                dto
+            );
+            var createScheduleHandler = new CreateScheduleHandler(_dbService.Object, _str.Object);
+            var result = await Assert.ThrowsAsync<ApiErrorException>(
+                async () =>
+                    await createScheduleHandler.Handle(
+                        createScheduleCommand,
+                        new CancellationToken()
+                    )
+            );
+
+            Assert.Equal(
+                JsonConvert.SerializeObject(
+                    new ErrorObject[]
+                    {
+                        new ErrorObject(
+                            $"The school year cannot be longer than {Configuration.maxSchoolYearDuration} month(s)"
+                        )
+                    }
+                ),
+                JsonConvert.SerializeObject(result.errors)
+            );
+        }
     }
 }

--- a/Test/Entities/EScheduleSettings/Commands/UpdateScheduleSettingsCommand.unit.cs
+++ b/Test/Entities/EScheduleSettings/Commands/UpdateScheduleSettingsCommand.unit.cs
@@ -6,6 +6,7 @@ using AlpimiAPI.Entities.EScheduleSettings;
 using AlpimiAPI.Entities.EScheduleSettings.Commands;
 using AlpimiAPI.Locales;
 using AlpimiAPI.Responses;
+using AlpimiAPI.Utilities;
 using AlpimiTest.TestSetup;
 using AlpimiTest.TestUtilities;
 using Microsoft.Extensions.Localization;
@@ -319,6 +320,46 @@ namespace AlpimiTest.Entities.EScheduleSettings.Commands
             Assert.Equal(
                 JsonConvert.SerializeObject(
                     new ErrorObject[] { new ErrorObject("LessonPeriods cannot overlap") }
+                ),
+                JsonConvert.SerializeObject(result.errors)
+            );
+        }
+
+        [Fact]
+        public async Task ThrowsErrorWhenSchoolYearDurationExceedsMaximumDuration()
+        {
+            var dto = MockData.GetUpdateScheduleSettingsDTO();
+            dto.SchoolYearEnd = new DateOnly(2029, 10, 10);
+            _dbService
+                .Setup(s => s.Get<ScheduleSettings>(It.IsAny<string>(), It.IsAny<object>()))
+                .ReturnsAsync(MockData.GetScheduleSettingsDetails());
+
+            var updateScheduleSettingsCommand = new UpdateScheduleSettingsCommand(
+                new Guid(),
+                dto,
+                new Guid(),
+                "Admin"
+            );
+            var updateScheduleSettingsHandler = new UpdateScheduleSettingsHandler(
+                _dbService.Object,
+                _str.Object
+            );
+            var result = await Assert.ThrowsAsync<ApiErrorException>(
+                async () =>
+                    await updateScheduleSettingsHandler.Handle(
+                        updateScheduleSettingsCommand,
+                        new CancellationToken()
+                    )
+            );
+
+            Assert.Equal(
+                JsonConvert.SerializeObject(
+                    new ErrorObject[]
+                    {
+                        new ErrorObject(
+                            $"The school year cannot be longer than {Configuration.maxSchoolYearDuration} month(s)"
+                        )
+                    }
                 ),
                 JsonConvert.SerializeObject(result.errors)
             );

--- a/Test/Plan/Schedule.md
+++ b/Test/Plan/Schedule.md
@@ -35,6 +35,9 @@
 - [ThrowsErrorWhenNameContainsIllegalAnSymbol](../Entities/ESchedule/Commands/CreateScheduleCommand.unit.cs) - **unit**  
   Check if returns an error when name contains an illegal symbol
 
+- [ThrowsErrorWhenSchoolYearDurationExceedsMaximumDuration()](../Entities/ESchedule/Commands/CreateScheduleCommand.unit.cs) - **unit**    
+  Check if returns an error when the school year will last longer than the maxiumum amount
+
 
 ## `DELETE` `api/Schedule/{id}`
 

--- a/Test/Plan/ScheduleSettings.md
+++ b/Test/Plan/ScheduleSettings.md
@@ -43,6 +43,9 @@
 
 - [ThrowsErrorWhenLessonPeriodsOverlapAfterUpdatingSchoolHour()](../Entities/EScheduleSettings/Commands/UpdateScheduleSettingsCommand.unit.cs) - **unit**  
   Check if returns an error when incorrect school hour is provided
+
+- [ThrowsErrorWhenSchoolYearDurationExceedsMaximumDuration()](../Entities/EScheduleSettings/Commands/UpdateScheduleSettingsCommand.unit.cs) - **unit**  
+  Check if returns an error when the school year will last longer than the maxiumum amount
   
 
 ## `GET` `api/ScheduleSettings/{id}`

--- a/Test/Setup/ResourceSetup.cs
+++ b/Test/Setup/ResourceSetup.cs
@@ -96,6 +96,13 @@ namespace AlpimiTest.TestSetup
                 )
             },
             {
+                "scheduleDuration",
+                args => new LocalizedString(
+                    "scheduleDuration",
+                    string.Format("The school year cannot be longer than {0} month(s)", args[0])
+                )
+            },
+            {
                 "dateOutOfRange",
                 args => new LocalizedString(
                     "dateOutofRange",

--- a/Test/Setup/TestDatabaseFactory.cs
+++ b/Test/Setup/TestDatabaseFactory.cs
@@ -14,6 +14,8 @@ namespace AlpimiTest.TestSetup
 
             builder.UseEnvironment("Testing");
 
+            Configuration.maxSchoolYearDuration = 80;
+
             builder.ConfigureServices(
                 (context, services) =>
                 {


### PR DESCRIPTION
Dodałem ograniczenie do 24 mieśięcy na długość roku szkolnego
można zmienić w configuracji