### PR TITLE
Fix get alls for users

### DIFF
--- a/API/Entities/EAvailability/Queries/GetAllAvailabilityByTeacherQuery.cs
+++ b/API/Entities/EAvailability/Queries/GetAllAvailabilityByTeacherQuery.cs
@@ -114,8 +114,8 @@ namespace AlpimiAPI.Entities.EAvailability.Queries
                             COUNT(*)
                             FROM [Availability] a
                             INNER JOIN [Teacher] t ON t.[Id] = a.[TeacherId]
-                            INNER JOIN [Schedule] s ON s.[Id]= t.[TeacherId]
-                            INNER JOIN [ScheduleSettings] ss ON ss.[TeacherId] = s.[Id]
+                            INNER JOIN [Schedule] s ON s.[Id]= t.[ScheduleId]
+                            INNER JOIN [ScheduleSettings] ss ON ss.[ScheduleId] = s.[Id]
                             WHERE s.[UserId] = @FilteredId AND t.[Id] = @TeacherId;",
                         request
                     );
@@ -125,8 +125,8 @@ namespace AlpimiAPI.Entities.EAvailability.Queries
                             a.[Id], a.[WeekDay], a.[Start], a.[End], a.[TeacherId]
                             FROM [Availability] a
                             INNER JOIN [Teacher] t ON t.[Id] = a.[TeacherId]
-                            INNER JOIN [Schedule] s ON s.[Id]= t.[TeacherId]
-                            INNER JOIN [ScheduleSettings] ss ON ss.[TeacherId] = s.[Id]
+                            INNER JOIN [Schedule] s ON s.[Id]= t.[ScheduleId]
+                            INNER JOIN [ScheduleSettings] ss ON ss.[ScheduleId] = s.[Id]
                             WHERE s.[UserId] = @FilteredId AND t.[Id] = @TeacherId 
                             ORDER BY
                             {request.Pagination.SortBy}

--- a/API/Entities/EClassroom/Queries/GetAllClassroomsQuery.cs
+++ b/API/Entities/EClassroom/Queries/GetAllClassroomsQuery.cs
@@ -124,7 +124,7 @@ namespace AlpimiAPI.Entities.EClassroom.Queries
                     classrooms = await _dbService.GetAll<Classroom>(
                         $@"
                             SELECT 
-                            c.[Id], c.[Name], c.[Capacity], [ScheduleId] 
+                            c.[Id], c.[Name], c.[Capacity], c.[ScheduleId] 
                             FROM [Classroom] c
                             INNER JOIN [Schedule] s ON s.[Id] = c.[ScheduleId]
                             INNER JOIN [ScheduleSettings] ss ON ss.[ScheduleId] = s.[Id]

--- a/API/Entities/EGroup/Queries/GetAllGroupsByScheduleQuery.cs
+++ b/API/Entities/EGroup/Queries/GetAllGroupsByScheduleQuery.cs
@@ -118,7 +118,7 @@ namespace AlpimiAPI.Entities.EGroup.Queries
                     groups = await _dbService.GetAll<Group>(
                         $@"
                             SELECT 
-                            g.[Id], g.[Name], [StudentCount], [ScheduleId] 
+                            g.[Id], g.[Name], g.[StudentCount], g.[ScheduleId] 
                             FROM [Group] g
                             INNER JOIN [Schedule] s ON s.[Id]=g.[ScheduleId]
                             INNER JOIN [ScheduleSettings] ss ON ss.[ScheduleId] = s.[Id]

--- a/API/Entities/ELesson/LessonController.cs
+++ b/API/Entities/ELesson/LessonController.cs
@@ -168,7 +168,7 @@ namespace AlpimiAPI.Entities.ELesson
         }
 
         /// <summary>
-        /// Gets all Lessons by SubroupId or GroupId
+        /// Gets all Lessons by SubroupId, GroupId, TeacherId or ScheduleId
         /// </summary>
         /// <remarks>
         /// - JWT token is required

--- a/API/Entities/ELesson/Queries/GetAllLessonsQuery.cs
+++ b/API/Entities/ELesson/Queries/GetAllLessonsQuery.cs
@@ -91,7 +91,8 @@ namespace AlpimiAPI.Entities.ELesson.Queries
                             LEFT JOIN [LessonSubgroup] lsg ON lsg.[LessonId] = l.[Id]
                             LEFT JOIN [Subgroup] sg ON sg.[Id] = lsg.[SubgroupId]
                             LEFT JOIN [Group] g ON g.[Id] = sg.[GroupId]
-                            WHERE sg.[Id] = @Id OR g.[Id] = @Id OR t.[Id] = @Id;",
+                            LEFT JOIN [Schedule] s ON s.[Id] = t.[ScheduleId]
+                            WHERE sg.[Id] = @Id OR g.[Id] = @Id OR t.[Id] = @Id OR s.[Id] = @Id;",
                         request
                     );
                     lessons = await _dbService.GetAll<Lesson>(
@@ -103,7 +104,8 @@ namespace AlpimiAPI.Entities.ELesson.Queries
                             LEFT JOIN [LessonSubgroup] lsg ON lsg.[LessonId] = l.[Id]
                             LEFT JOIN [Subgroup] sg ON sg.[Id] = lsg.[SubgroupId]
                             LEFT JOIN [Group] g ON g.[Id] = sg.[GroupId]
-                            WHERE t.[Id] = @Id OR g.[Id] = @Id OR sg.[Id] = @Id
+                            LEFT JOIN [Schedule] s ON s.[Id] = t.[ScheduleId]
+                            WHERE t.[Id] = @Id OR g.[Id] = @Id OR sg.[Id] = @Id OR s.[Id] = @Id
                             ORDER BY
                             {request.Pagination.SortBy}
                             {request.Pagination.SortOrder}
@@ -125,7 +127,7 @@ namespace AlpimiAPI.Entities.ELesson.Queries
                             LEFT JOIN [LessonSubgroup] lsg ON lsg.[LessonId] = l.[Id]
                             LEFT JOIN [Subgroup] sg ON sg.[Id] = lsg.[SubgroupId]
                             LEFT JOIN [Group] g ON g.[Id] = sg.[GroupId]
-                            WHERE s.[UserId] = @FilteredId AND (t.[Id] = @Id OR g.[Id] = @Id OR sg.[Id] = @Id);",
+                            WHERE s.[UserId] = @FilteredId AND (t.[Id] = @Id OR g.[Id] = @Id OR sg.[Id] = @Id OR s.[Id] = @Id);",
                         request
                     );
                     lessons = await _dbService.GetAll<Lesson>(
@@ -138,7 +140,7 @@ namespace AlpimiAPI.Entities.ELesson.Queries
                             LEFT JOIN [LessonSubgroup] lsg ON lsg.[LessonId] = l.[Id]
                             LEFT JOIN [Subgroup] sg ON sg.[Id] = lsg.[SubgroupId]
                             LEFT JOIN [Group] g ON g.[Id] = sg.[GroupId]
-                            WHERE s.[UserId] = @FilteredId AND (t.[Id] = @Id OR g.[Id] = @Id OR sg.[Id] = @Id)
+                            WHERE s.[UserId] = @FilteredId AND (t.[Id] = @Id OR g.[Id] = @Id OR sg.[Id] = @Id OR s.[Id] = @Id)
                             ORDER BY
                             {request.Pagination.SortBy}
                             {request.Pagination.SortOrder}

--- a/API/Entities/ESubgroup/Queries/GetAllSubgroupsQuery.cs
+++ b/API/Entities/ESubgroup/Queries/GetAllSubgroupsQuery.cs
@@ -125,7 +125,7 @@ namespace AlpimiAPI.Entities.ESubgroup.Queries
                             LEFT JOIN [Student] st ON st.[Id] = ssg.[StudentId]
                             LEFT JOIN [LessonSubgroup] lsg ON lsg.[SubgroupId] = sg.[Id]
                             LEFT JOIN [Lesson] l ON l.[Id] = lsg.[LessonId]
-                            WHERE (s.[UserId] = @FilteredId OR ss.[IsPublic] = 'TRUE') AND (sg.[GroupId] = @Id OR st.[Id] = @Id l.[Id] = @Id);",
+                            WHERE (s.[UserId] = @FilteredId OR ss.[IsPublic] = 'TRUE') AND (sg.[GroupId] = @Id OR st.[Id] = @Id OR l.[Id] = @Id);",
                         request
                     );
                     subgroups = await _dbService.GetAll<Subgroup>(

--- a/Test/Entities/EAvailability/AvailabilityController.test.cs
+++ b/Test/Entities/EAvailability/AvailabilityController.test.cs
@@ -119,6 +119,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(teacherId1.ToString(), stringResponse);
         }
@@ -137,6 +138,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(teacherId1.ToString(), stringResponse);
         }
@@ -156,6 +158,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(teacherId1.ToString(), stringResponse);
         }
@@ -175,6 +178,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(Convert.ToString(availabilityRequest.TeacherId)!, stringResponse);
         }
@@ -194,6 +198,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(Convert.ToString(availabilityRequest.TeacherId)!, stringResponse);
         }
@@ -214,6 +219,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(Convert.ToString(availabilityRequest.TeacherId)!, stringResponse);
         }
@@ -305,6 +311,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains("\"weekDay\":" + dto.WeekDay.ToString(), stringResponse);
@@ -336,6 +343,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(
@@ -362,6 +370,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(teacherId1.ToString(), stringResponse);
@@ -386,6 +395,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={new Guid()}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(teacherId1.ToString(), stringResponse);
@@ -411,6 +421,7 @@ namespace AlpimiTest.Entities.EAvailability
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Availability{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(teacherId1.ToString(), stringResponse);

--- a/Test/Entities/EClassroom/ClassroomController.test.cs
+++ b/Test/Entities/EClassroom/ClassroomController.test.cs
@@ -109,6 +109,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomRequest.Name!, stringResponse);
         }
@@ -127,6 +128,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(classroomRequest.Name!, stringResponse);
         }
@@ -146,6 +148,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomRequest.Name!, stringResponse);
         }
@@ -169,6 +172,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={classroomTypeId}";
             response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomRequest.Name!, stringResponse);
         }
@@ -188,6 +192,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(classroomRequest.Name!, stringResponse);
         }
@@ -207,6 +212,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomRequest.Name!, stringResponse);
         }
@@ -227,6 +233,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(classroomRequest.Name!, stringResponse);
         }
@@ -277,6 +284,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={classroomTypeId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomUpdateRequest.Name!, stringResponse);
         }
@@ -382,6 +390,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomRequest1.Name!, stringResponse);
@@ -407,6 +416,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={classromTypeId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomRequest1.Name!, stringResponse);
@@ -429,6 +439,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomRequest1.Name!, stringResponse);
@@ -449,6 +460,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(classroomRequest1.Name!, stringResponse);
@@ -469,6 +481,7 @@ namespace AlpimiTest.Entities.EClassroom
 
             var query = $"?id={new Guid()}";
             var response = await _client.GetAsync($"/api/Classroom{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(classroomRequest1.Name!, stringResponse);

--- a/Test/Entities/EClassroomType/ClassroomTypeController.test.cs
+++ b/Test/Entities/EClassroomType/ClassroomTypeController.test.cs
@@ -116,6 +116,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomTypeRequest.Name!, stringResponse);
         }
@@ -134,6 +135,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(classroomTypeRequest.Name!, stringResponse);
         }
@@ -153,6 +155,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomTypeRequest.Name!, stringResponse);
         }
@@ -172,6 +175,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(classroomTypeRequest.Name!, stringResponse);
         }
@@ -191,6 +195,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomTypeRequest.Name!, stringResponse);
         }
@@ -211,6 +216,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(classroomTypeRequest.Name!, stringResponse);
         }
@@ -347,6 +353,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomTypeRequest1.Name!, stringResponse);
@@ -375,6 +382,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={classroomId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomTypeRequest1.Name!, stringResponse);
@@ -418,6 +426,7 @@ namespace AlpimiTest.Entities.EClassroomType
             var lessonId = await DbHelper.SetupLesson(_client, lessonRequest);
             var query = $"?id={lessonId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomTypeRequest1.Name!, stringResponse);
@@ -438,6 +447,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(classroomTypeRequest1.Name!, stringResponse);
@@ -458,6 +468,7 @@ namespace AlpimiTest.Entities.EClassroomType
 
             var query = $"?id={new Guid()}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(classroomTypeRequest1.Name!, stringResponse);

--- a/Test/Entities/ECollisionType/CollisionTypeController.test.cs
+++ b/Test/Entities/ECollisionType/CollisionTypeController.test.cs
@@ -112,6 +112,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(collisionTypeRequest.Name!, stringResponse);
         }
@@ -130,6 +131,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(collisionTypeRequest.Name!, stringResponse);
         }
@@ -149,6 +151,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(collisionTypeRequest.Name!, stringResponse);
         }
@@ -168,6 +171,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(collisionTypeRequest.Name!, stringResponse);
         }
@@ -187,6 +191,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(collisionTypeRequest.Name!, stringResponse);
         }
@@ -207,6 +212,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(collisionTypeRequest.Name!, stringResponse);
         }
@@ -345,6 +351,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(collisionTypeRequest1.Name!, stringResponse);
@@ -365,6 +372,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(collisionTypeRequest1.Name!, stringResponse);
@@ -385,6 +393,7 @@ namespace AlpimiTest.Entities.ECollisionType
 
             var query = $"?scheduleId={new Guid()}";
             var response = await _client.GetAsync($"/api/CollisionType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(collisionTypeRequest1.Name!, stringResponse);

--- a/Test/Entities/EDayOff/DayOffController.test.cs
+++ b/Test/Entities/EDayOff/DayOffController.test.cs
@@ -103,6 +103,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(dayOffRequest.Name!, stringResponse);
         }
@@ -121,6 +122,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(dayOffRequest.Name!, stringResponse);
         }
@@ -140,6 +142,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(dayOffRequest.Name!, stringResponse);
         }
@@ -159,6 +162,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/DayOff");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(dayOffRequest.Name!, stringResponse);
         }
@@ -249,6 +253,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(dayOffUpdateRequest.Name!, stringResponse);
         }
@@ -272,6 +277,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(dayOffUpdateRequest.Name!, stringResponse);
         }
@@ -290,6 +296,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(dayOffRequest1.Name!, stringResponse);
@@ -308,6 +315,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(dayOffRequest1.Name!, stringResponse);
@@ -328,6 +336,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(dayOffRequest1.Name!, stringResponse);
@@ -348,6 +357,7 @@ namespace AlpimiTest.Entities.EDayOff
 
             var query = $"?scheduleId={new Guid()}";
             var response = await _client.GetAsync($"/api/DayOff{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(dayOffRequest1.Name!, stringResponse);

--- a/Test/Entities/EGroup/GroupController.test.cs
+++ b/Test/Entities/EGroup/GroupController.test.cs
@@ -109,6 +109,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(groupRequest.Name!, stringResponse);
         }
@@ -127,6 +128,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(groupRequest.Name!, stringResponse);
         }
@@ -146,6 +148,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(groupRequest.Name!, stringResponse);
         }
@@ -165,6 +168,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(groupRequest.Name!, stringResponse);
         }
@@ -184,6 +188,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(groupRequest.Name!, stringResponse);
         }
@@ -204,6 +209,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(groupRequest.Name!, stringResponse);
         }
@@ -330,6 +336,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(groupRequest1.Name!, stringResponse);
@@ -348,6 +355,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(groupRequest1.Name!, stringResponse);
@@ -368,6 +376,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(groupRequest1.Name!, stringResponse);
@@ -388,6 +397,7 @@ namespace AlpimiTest.Entities.EGroup
 
             var query = $"?scheduleId={new Guid()}";
             var response = await _client.GetAsync($"/api/Group{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(groupRequest1.Name!, stringResponse);

--- a/Test/Entities/ELesson/LessonController.test.cs
+++ b/Test/Entities/ELesson/LessonController.test.cs
@@ -147,6 +147,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={teacherId1}";
             response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonRequest.Name!, stringResponse);
         }
@@ -169,6 +170,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonRequest.Name!, stringResponse);
         }
@@ -192,6 +194,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonRequest.Name!, stringResponse);
         }
@@ -218,6 +221,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={jsonLessonId!.Content}";
             response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomTypeRequest.Name!, stringResponse);
         }
@@ -241,6 +245,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={teacherId1}";
             response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonRequest.Name!, stringResponse);
         }
@@ -264,6 +269,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonRequest.Name!, stringResponse);
         }
@@ -288,6 +294,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonRequest.Name!, stringResponse);
         }
@@ -337,6 +344,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={lessonId}";
             var response = await _client.GetAsync($"/api/ClassroomType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classromTypeRequest.Name!, stringResponse);
         }
@@ -450,6 +458,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(lessonRequest1.Name!, stringResponse);
@@ -478,6 +487,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?id={subgroupId1}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(lessonRequest1.Name!, stringResponse);
@@ -506,6 +516,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?groupId={groupId}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(lessonRequest1.Name!, stringResponse);
@@ -534,6 +545,7 @@ namespace AlpimiTest.Entities.ELesson
 
             var query = $"?groupId={new Guid()}";
             var response = await _client.GetAsync($"/api/Lesson{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(lessonRequest1.Name!, stringResponse);

--- a/Test/Entities/ELessonBlock/LessonBlockController.test.cs
+++ b/Test/Entities/ELessonBlock/LessonBlockController.test.cs
@@ -169,6 +169,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={groupId}";
             response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomId1.ToString(), stringResponse);
         }
@@ -235,6 +236,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(classroomId1.ToString(), stringResponse);
         }
@@ -257,6 +259,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(classroomId1.ToString(), stringResponse);
         }
@@ -333,6 +336,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={groupId}";
             response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(Convert.ToString(lessonBlockRequest.LessonDate)!, stringResponse);
         }
@@ -402,6 +406,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(Convert.ToString(lessonBlockRequest.LessonId)!, stringResponse);
         }
@@ -425,6 +430,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(Convert.ToString(lessonBlockRequest.LessonDate)!, stringResponse);
         }
@@ -663,6 +669,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains("\"lessonStart\":" + dto.LessonStart, stringResponse);
             Assert.Contains("\"lessonEnd\":" + dto.LessonEnd, stringResponse);
@@ -691,6 +698,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(
@@ -722,6 +730,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -754,6 +763,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={subgroupId1}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -786,6 +796,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -818,6 +829,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={classroomId1}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -850,6 +862,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={lessonId1}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -882,6 +895,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={teacherId1}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -914,6 +928,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={clusterId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(classroomId1.ToString(), stringResponse);
@@ -944,6 +959,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -976,6 +992,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={lessonId1}&fromDate=10.10.2023&toDate=10.10.2023";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);
@@ -1008,6 +1025,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={new Guid()}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(classroomId1.ToString(), stringResponse);
@@ -1040,6 +1058,7 @@ namespace AlpimiTest.Entities.ELessonBlock
 
             var query = $"?id={lessonId1}";
             var response = await _client.GetAsync($"/api/LessonBlock{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(classroomId1.ToString(), stringResponse);
@@ -1063,6 +1082,7 @@ namespace AlpimiTest.Entities.ELessonBlock
             );
 
             var response = await _client.GetAsync($"/api/LessonBlock/{lessonBlockId}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(classroomId1.ToString(), stringResponse);

--- a/Test/Entities/ELessonPeriod/LessonPeriodController.test.cs
+++ b/Test/Entities/ELessonPeriod/LessonPeriodController.test.cs
@@ -104,6 +104,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonPeriodRequest.Start.ToString()!, stringResponse);
         }
@@ -122,6 +123,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonPeriodRequest.Start.ToString()!, stringResponse);
         }
@@ -141,6 +143,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonPeriodRequest.Start.ToString()!, stringResponse);
         }
@@ -160,6 +163,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonPeriodRequest.Start.ToString()!, stringResponse);
         }
@@ -179,6 +183,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonPeriodRequest.Start.ToString()!, stringResponse);
         }
@@ -199,6 +204,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonPeriodRequest.Start.ToString()!, stringResponse);
         }
@@ -290,6 +296,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(dto.Start.ToString()!, stringResponse);
@@ -317,6 +324,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(lessonPeriodUpdateRequest.Start.ToString()!, stringResponse);
@@ -336,6 +344,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(lessonPeriodRequest1.Start.ToString()!, stringResponse);
@@ -354,6 +363,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(lessonPeriodRequest1.Start.ToString()!, stringResponse);
@@ -374,6 +384,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(lessonPeriodRequest1.Start.ToString()!, stringResponse);
@@ -394,6 +405,7 @@ namespace AlpimiTest.Entities.ELessonPeriod
 
             var query = $"?scheduleId={new Guid()}";
             var response = await _client.GetAsync($"/api/LessonPeriod{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(lessonPeriodRequest1.Start.ToString()!, stringResponse);

--- a/Test/Entities/ELessonType/LessonTypeController.test.cs
+++ b/Test/Entities/ELessonType/LessonTypeController.test.cs
@@ -113,6 +113,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonTypeRequest.Name!, stringResponse);
         }
@@ -131,6 +132,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonTypeRequest.Name!, stringResponse);
         }
@@ -150,6 +152,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonTypeRequest.Name!, stringResponse);
         }
@@ -169,6 +172,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonTypeRequest.Name!, stringResponse);
         }
@@ -188,6 +192,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(lessonTypeRequest.Name!, stringResponse);
         }
@@ -208,6 +213,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(lessonTypeRequest.Name!, stringResponse);
         }
@@ -346,6 +352,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(lessonTypeRequest1.Name!, stringResponse);
@@ -366,6 +373,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(lessonTypeRequest1.Name!, stringResponse);
@@ -386,6 +394,7 @@ namespace AlpimiTest.Entities.ELessonType
 
             var query = $"?scheduleId={new Guid()}";
             var response = await _client.GetAsync($"/api/LessonType{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(lessonTypeRequest1.Name!, stringResponse);

--- a/Test/Entities/ESchedule/ScheduleController.test.cs
+++ b/Test/Entities/ESchedule/ScheduleController.test.cs
@@ -224,6 +224,7 @@ namespace AlpimiTest.Entities.ESchedule
             );
 
             var response = await _client.GetAsync("/api/Schedule");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(scheduleRequest1.Name!, stringResponse);
@@ -247,6 +248,7 @@ namespace AlpimiTest.Entities.ESchedule
             );
 
             var response = await _client.GetAsync("/api/Schedule");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(scheduleRequest1.Name!, stringResponse);
@@ -270,6 +272,7 @@ namespace AlpimiTest.Entities.ESchedule
             );
 
             var response = await _client.GetAsync("/api/Schedule");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(scheduleRequest1.Name!, stringResponse);
@@ -291,6 +294,7 @@ namespace AlpimiTest.Entities.ESchedule
 
             var query = $"?url={user.CustomURL}";
             var response = await _client.GetAsync($"/api/Schedule/byURL{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(scheduleRequest1.Name!, stringResponse);
@@ -310,6 +314,7 @@ namespace AlpimiTest.Entities.ESchedule
 
             var query = $"?url={user.CustomURL}";
             var response = await _client.GetAsync($"/api/Schedule/byURL{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(scheduleRequest1.Name!, stringResponse);
@@ -331,6 +336,7 @@ namespace AlpimiTest.Entities.ESchedule
 
             var query = $"?url={user.CustomURL}";
             var response = await _client.GetAsync($"/api/Schedule/byURL{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(scheduleRequest1.Name!, stringResponse);
@@ -351,6 +357,7 @@ namespace AlpimiTest.Entities.ESchedule
 
             var query = "?url=wrongURL";
             var response = await _client.GetAsync($"/api/Schedule/byURL{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(scheduleRequest1.Name!, stringResponse);

--- a/Test/Entities/EStudent/StudentController.test.cs
+++ b/Test/Entities/EStudent/StudentController.test.cs
@@ -128,6 +128,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(studentRequest.AlbumNumber!, stringResponse);
         }
@@ -146,6 +147,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(studentRequest.AlbumNumber!, stringResponse);
         }
@@ -165,6 +167,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(studentRequest.AlbumNumber!, stringResponse);
         }
@@ -184,6 +187,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={subgroupId}";
             response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(studentRequest.AlbumNumber!, stringResponse);
         }
@@ -203,6 +207,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(studentRequest.AlbumNumber!, stringResponse);
         }
@@ -222,6 +227,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(studentRequest.AlbumNumber!, stringResponse);
         }
@@ -242,6 +248,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(studentRequest.AlbumNumber!, stringResponse);
         }
@@ -288,6 +295,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={subgroupId}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(studentUpdateRequest.AlbumNumber!, stringResponse);
         }
@@ -393,6 +401,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(studentRequest1.AlbumNumber!, stringResponse);
@@ -413,6 +422,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={scheduleId}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(studentRequest1.AlbumNumber!, stringResponse);
@@ -434,6 +444,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={subgroupId}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(studentRequest1.AlbumNumber!, stringResponse);
@@ -454,6 +465,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={groupId1}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(studentRequest1.AlbumNumber!, stringResponse);
@@ -474,6 +486,7 @@ namespace AlpimiTest.Entities.EStudent
 
             var query = $"?id={new Guid()}";
             var response = await _client.GetAsync($"/api/Student{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(studentRequest1.AlbumNumber!, stringResponse);

--- a/Test/Entities/ESubgroup/SubgroupController.test.cs
+++ b/Test/Entities/ESubgroup/SubgroupController.test.cs
@@ -114,6 +114,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(subgroupRequest.Name!, stringResponse);
         }
@@ -132,6 +133,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(subgroupRequest.Name!, stringResponse);
         }
@@ -151,6 +153,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(subgroupRequest.Name!, stringResponse);
         }
@@ -170,6 +173,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(subgroupRequest.Name!, stringResponse);
         }
@@ -189,6 +193,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(subgroupRequest.Name!, stringResponse);
         }
@@ -209,6 +214,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(subgroupRequest.Name!, stringResponse);
         }
@@ -342,6 +348,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(subgroupRequest1.Name!, stringResponse);
@@ -365,6 +372,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={studentId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(subgroupRequest1.Name!, stringResponse);
@@ -400,6 +408,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={lessonId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(subgroupRequest1.Name!, stringResponse);
@@ -418,6 +427,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(subgroupRequest1.Name!, stringResponse);
@@ -438,6 +448,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={groupId}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(subgroupRequest1.Name!, stringResponse);
@@ -458,6 +469,7 @@ namespace AlpimiTest.Entities.ESubgroup
 
             var query = $"?id={Guid.NewGuid()}";
             var response = await _client.GetAsync($"/api/Subgroup{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(subgroupRequest1.Name!, stringResponse);

--- a/Test/Entities/ETeacher/TeacherController.test.cs
+++ b/Test/Entities/ETeacher/TeacherController.test.cs
@@ -113,6 +113,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(teacherRequest.Name!, stringResponse);
         }
@@ -131,6 +132,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(teacherRequest.Name!, stringResponse);
         }
@@ -150,6 +152,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(teacherRequest.Name!, stringResponse);
         }
@@ -169,6 +172,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(teacherRequest.Name!, stringResponse);
         }
@@ -188,6 +192,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.Contains(teacherRequest.Name!, stringResponse);
         }
@@ -208,6 +213,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
             Assert.DoesNotContain(teacherRequest.Name!, stringResponse);
         }
@@ -340,6 +346,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(teacherRequest1.Name!, stringResponse);
@@ -360,6 +367,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={scheduleId}";
             var response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(teacherRequest1.Name!, stringResponse);
@@ -380,6 +388,7 @@ namespace AlpimiTest.Entities.ETeacher
 
             var query = $"?scheduleId={new Guid()}";
             var response = await _client.GetAsync($"/api/Teacher{query}");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
             Assert.DoesNotContain(teacherRequest1.Name!, stringResponse);


### PR DESCRIPTION
Get all should work now
GetAll tests now check if they get an OK status due to the fact that turning a response into a string does not care about it being an error